### PR TITLE
Create /vr-refget redirection

### DIFF
--- a/ga4gh/.htaccess
+++ b/ga4gh/.htaccess
@@ -23,3 +23,6 @@ RewriteRule ^minutes/case-discovery$ https://docs.google.com/document/d/1k-YyTA4
 
 # Clin-Pheno Work Stream Links
 RewriteRule ^minutes/phenopackets$ https://docs.google.com/document/d/1gxRaduk2bv6_cCSiDVJomVtfMD2AOFeDVGELsShh21U/edit?usp=sharing [R=302,L]
+
+# Refget VR links
+^vr-refget(.+)$ https://193.62.54.154/$1 [R=302,B,L]

--- a/ga4gh/.htaccess
+++ b/ga4gh/.htaccess
@@ -25,5 +25,5 @@ RewriteRule ^minutes/case-discovery$ https://docs.google.com/document/d/1k-YyTA4
 RewriteRule ^minutes/phenopackets$ https://docs.google.com/document/d/1gxRaduk2bv6_cCSiDVJomVtfMD2AOFeDVGELsShh21U/edit?usp=sharing [R=302,L]
 
 # Refget links
-^vr-refget(.+)$ https://193.62.54.154/$1 [R=302,B,L]
-^serverless-refget(.+)$ https://cl9lba3no5.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]
+RewriteRule ^vr-refget(.+)$ https://193.62.54.154/$1 [R=302,B,L]
+RewriteRule ^serverless-refget(.+)$ https://cl9lba3no5.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]

--- a/ga4gh/.htaccess
+++ b/ga4gh/.htaccess
@@ -24,5 +24,6 @@ RewriteRule ^minutes/case-discovery$ https://docs.google.com/document/d/1k-YyTA4
 # Clin-Pheno Work Stream Links
 RewriteRule ^minutes/phenopackets$ https://docs.google.com/document/d/1gxRaduk2bv6_cCSiDVJomVtfMD2AOFeDVGELsShh21U/edit?usp=sharing [R=302,L]
 
-# Refget VR links
+# Refget links
 ^vr-refget(.+)$ https://193.62.54.154/$1 [R=302,B,L]
+^serverless-refget(.+)$ https://cl9lba3no5.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]


### PR DESCRIPTION
vr-refget redirection is a new service provided currently by an EBI service to help provide alias lookup for the vr specification. All url content beyond the initial /vr-refget URL should be redirected to the above address.