### PR TITLE
Create the /discovery/service-info-v1.yaml link

### DIFF
--- a/ga4gh/.htaccess
+++ b/ga4gh/.htaccess
@@ -27,3 +27,6 @@ RewriteRule ^minutes/phenopackets$ https://docs.google.com/document/d/1gxRaduk2b
 # Refget links
 RewriteRule ^vr-refget(.+)$ https://193.62.54.154/$1 [R=302,B,L]
 RewriteRule ^serverless-refget(.+)$ https://cl9lba3no5.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]
+
+# Discovery Links
+RewriteRule ^discovery/service-info-v1.yaml$ https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/develop/service-info.yaml [R=302,B,L]


### PR DESCRIPTION
Creating a link to redirect to the current service-info location (version 1). Plan is to rewrite this to point to the live branch once successfully through PRC.